### PR TITLE
Adds a template for all single posts that adds a banner header to pre…

### DIFF
--- a/single.php
+++ b/single.php
@@ -1,0 +1,26 @@
+<?php
+/*
+Template Name: Single Post
+*/
+get_header(); ?>
+<?php $bannerBackground = get_template_directory_uri()."/img/gradient-banner.jpg"; ?>
+
+<div id="page-content-container">
+    <div id="page-content-banner" style="background: url('<?php echo $bannerBackground; ?>') no-repeat center top; background-size: cover;">
+        <div id="banner-background">
+        </div>
+        <div id="banner-title-container">
+            <div id="banner-title-text">
+                <?php wp_title(''); ?>
+            </div>
+        </div>
+    </div>
+    <div id="page-content-body">
+        <div class="content-text">
+            <?php if (have_posts()) : while (have_posts()) : the_post();?>
+                <?php the_content(); ?>
+            <?php endwhile; endif; ?>
+        </div>
+    </div>
+</div>
+<?php get_footer(); ?>


### PR DESCRIPTION
…vent the logo from overlapping the content

Before:
<img width="1678" alt="screen shot 2017-08-29 at 4 08 44 pm" src="https://user-images.githubusercontent.com/13244305/29844704-d333f314-8cd5-11e7-8341-ee6daed08a3d.png">

After:
<img width="1421" alt="screen shot 2017-08-29 at 4 20 29 pm" src="https://user-images.githubusercontent.com/13244305/29844764-10f1cf50-8cd6-11e7-95bc-5caef33c1e15.png">


